### PR TITLE
fix some line break issues in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Or, if you're old fashioned, you can just run `make` :)
 
 
 oh, and it runs doom
+
 ![It runs doom](https://github.com/nickwanninger/chariot/raw/trunk/meta/DOOM.png)
 
-You just need to put your copy of doom1.wad in /usr/res/misc/doom1.wad and `/bin/doom` will run
+You just need to put your copy of doom1.wad in /usr/res/misc/doom1.wad and `/bin/doom` will run.
 Either that or run `doom -iwad <path to wad>`


### PR DESCRIPTION
Remember that markdown ignores line breaks. It's two line breaks to make a new paragraph.